### PR TITLE
Added postgresql-9.0.json, postgresql-9.1.json and postgresql-9.2.json

### DIFF
--- a/words/postgresql-9.0.json
+++ b/words/postgresql-9.0.json
@@ -1,0 +1,300 @@
+{
+  "platform": "PostgreSQL",
+  "version": "9.0",
+  "words": [
+    {
+      "word": "ALL"
+    },
+    {
+      "word": "ANALYSE"
+    },
+    {
+      "word": "ANALYZE"
+    },
+    {
+      "word": "AND"
+    },
+    {
+      "word": "ANY"
+    },
+    {
+      "word": "ARRAY"
+    },
+    {
+      "word": "AS"
+    },
+    {
+      "word": "ASC"
+    },
+    {
+      "word": "ASYMMETRIC"
+    },
+    {
+      "word": "AUTHORIZATION"
+    },
+    {
+      "word": "BINARY"
+    },
+    {
+      "word": "BOTH"
+    },
+    {
+      "word": "CASE"
+    },
+    {
+      "word": "CAST"
+    },
+    {
+      "word": "CHECK"
+    },
+    {
+      "word": "COLLATE"
+    },
+    {
+      "word": "COLUMN"
+    },
+    {
+      "word": "CONCURRENTLY"
+    },
+    {
+      "word": "CONSTRAINT"
+    },
+    {
+      "word": "CREATE"
+    },
+    {
+      "word": "CROSS"
+    },
+    {
+      "word": "CURRENT_CATALOG"
+    },
+    {
+      "word": "CURRENT_DATE"
+    },
+    {
+      "word": "CURRENT_ROLE"
+    },
+    {
+      "word": "CURRENT_SCHEMA"
+    },
+    {
+      "word": "CURRENT_TIME"
+    },
+    {
+      "word": "CURRENT_TIMESTAMP"
+    },
+    {
+      "word": "CURRENT_USER"
+    },
+    {
+      "word": "DEFAULT"
+    },
+    {
+      "word": "DEFERRABLE"
+    },
+    {
+      "word": "DESC"
+    },
+    {
+      "word": "DISTINCT"
+    },
+    {
+      "word": "DO"
+    },
+    {
+      "word": "ELSE"
+    },
+    {
+      "word": "END"
+    },
+    {
+      "word": "EXCEPT"
+    },
+    {
+      "word": "FALSE"
+    },
+    {
+      "word": "FETCH"
+    },
+    {
+      "word": "FOR"
+    },
+    {
+      "word": "FOREIGN"
+    },
+    {
+      "word": "FREEZE"
+    },
+    {
+      "word": "FROM"
+    },
+    {
+      "word": "FULL"
+    },
+    {
+      "word": "GRANT"
+    },
+    {
+      "word": "GROUP"
+    },
+    {
+      "word": "HAVING"
+    },
+    {
+      "word": "ILIKE"
+    },
+    {
+      "word": "IN"
+    },
+    {
+      "word": "INITIALLY"
+    },
+    {
+      "word": "INNER"
+    },
+    {
+      "word": "INTERSECT"
+    },
+    {
+      "word": "INTO"
+    },
+    {
+      "word": "IS"
+    },
+    {
+      "word": "ISNULL"
+    },
+    {
+      "word": "JOIN"
+    },
+    {
+      "word": "LEADING"
+    },
+    {
+      "word": "LEFT"
+    },
+    {
+      "word": "LIKE"
+    },
+    {
+      "word": "LIMIT"
+    },
+    {
+      "word": "LOCALTIME"
+    },
+    {
+      "word": "LOCALTIMESTAMP"
+    },
+    {
+      "word": "NATURAL"
+    },
+    {
+      "word": "NEW"
+    },
+    {
+      "word": "NOT"
+    },
+    {
+      "word": "NOTNULL"
+    },
+    {
+      "word": "NULL"
+    },
+    {
+      "word": "OFFSET"
+    },
+    {
+      "word": "OLD"
+    },
+    {
+      "word": "ON"
+    },
+    {
+      "word": "ONLY"
+    },
+    {
+      "word": "OR"
+    },
+    {
+      "word": "ORDER"
+    },
+    {
+      "word": "OUTER"
+    },
+    {
+      "word": "OVERLAPS"
+    },
+    {
+      "word": "PLACING"
+    },
+    {
+      "word": "PRIMARY"
+    },
+    {
+      "word": "REFERENCES"
+    },
+    {
+      "word": "RETURNING"
+    },
+    {
+      "word": "RIGHT"
+    },
+    {
+      "word": "SELECT"
+    },
+    {
+      "word": "SESSION_USER"
+    },
+    {
+      "word": "SIMILAR"
+    },
+    {
+      "word": "SOME"
+    },
+    {
+      "word": "SYMMETRIC"
+    },
+    {
+      "word": "TABLE"
+    },
+    {
+      "word": "THEN"
+    },
+    {
+      "word": "TO"
+    },
+    {
+      "word": "TRAILING"
+    },
+    {
+      "word": "TRUE"
+    },
+    {
+      "word": "UNION"
+    },
+    {
+      "word": "UNIQUE"
+    },
+    {
+      "word": "USER"
+    },
+    {
+      "word": "USING"
+    },
+    {
+      "word": "VARIADIC"
+    },
+    {
+      "word": "VERBOSE"
+    },
+    {
+      "word": "WHEN"
+    },
+    {
+      "word": "WHERE"
+    },
+    {
+      "word": "WITH"
+    }
+  ]
+}

--- a/words/postgresql-9.1.json
+++ b/words/postgresql-9.1.json
@@ -1,0 +1,300 @@
+{
+  "platform": "PostgreSQL",
+  "version": "9.1",
+  "words": [
+    {
+      "word": "ALL"
+    },
+    {
+      "word": "ANALYSE"
+    },
+    {
+      "word": "ANALYZE"
+    },
+    {
+      "word": "AND"
+    },
+    {
+      "word": "ANY"
+    },
+    {
+      "word": "ARRAY"
+    },
+    {
+      "word": "AS"
+    },
+    {
+      "word": "ASC"
+    },
+    {
+      "word": "ASYMMETRIC"
+    },
+    {
+      "word": "AUTHORIZATION"
+    },
+    {
+      "word": "BINARY"
+    },
+    {
+      "word": "BOTH"
+    },
+    {
+      "word": "CASE"
+    },
+    {
+      "word": "CAST"
+    },
+    {
+      "word": "CHECK"
+    },
+    {
+      "word": "COLLATE"
+    },
+    {
+      "word": "COLUMN"
+    },
+    {
+      "word": "CONCURRENTLY"
+    },
+    {
+      "word": "CONSTRAINT"
+    },
+    {
+      "word": "CREATE"
+    },
+    {
+      "word": "CROSS"
+    },
+    {
+      "word": "CURRENT_CATALOG"
+    },
+    {
+      "word": "CURRENT_DATE"
+    },
+    {
+      "word": "CURRENT_ROLE"
+    },
+    {
+      "word": "CURRENT_SCHEMA"
+    },
+    {
+      "word": "CURRENT_TIME"
+    },
+    {
+      "word": "CURRENT_TIMESTAMP"
+    },
+    {
+      "word": "CURRENT_USER"
+    },
+    {
+      "word": "DEFAULT"
+    },
+    {
+      "word": "DEFERRABLE"
+    },
+    {
+      "word": "DESC"
+    },
+    {
+      "word": "DISTINCT"
+    },
+    {
+      "word": "DO"
+    },
+    {
+      "word": "ELSE"
+    },
+    {
+      "word": "END"
+    },
+    {
+      "word": "EXCEPT"
+    },
+    {
+      "word": "FALSE"
+    },
+    {
+      "word": "FETCH"
+    },
+    {
+      "word": "FOR"
+    },
+    {
+      "word": "FOREIGN"
+    },
+    {
+      "word": "FREEZE"
+    },
+    {
+      "word": "FROM"
+    },
+    {
+      "word": "FULL"
+    },
+    {
+      "word": "GRANT"
+    },
+    {
+      "word": "GROUP"
+    },
+    {
+      "word": "HAVING"
+    },
+    {
+      "word": "ILIKE"
+    },
+    {
+      "word": "IN"
+    },
+    {
+      "word": "INITIALLY"
+    },
+    {
+      "word": "INNER"
+    },
+    {
+      "word": "INTERSECT"
+    },
+    {
+      "word": "INTO"
+    },
+    {
+      "word": "IS"
+    },
+    {
+      "word": "ISNULL"
+    },
+    {
+      "word": "JOIN"
+    },
+    {
+      "word": "LEADING"
+    },
+    {
+      "word": "LEFT"
+    },
+    {
+      "word": "LIKE"
+    },
+    {
+      "word": "LIMIT"
+    },
+    {
+      "word": "LOCALTIME"
+    },
+    {
+      "word": "LOCALTIMESTAMP"
+    },
+    {
+      "word": "NATURAL"
+    },
+    {
+      "word": "NEW"
+    },
+    {
+      "word": "NOT"
+    },
+    {
+      "word": "NOTNULL"
+    },
+    {
+      "word": "NULL"
+    },
+    {
+      "word": "OFFSET"
+    },
+    {
+      "word": "OLD"
+    },
+    {
+      "word": "ON"
+    },
+    {
+      "word": "ONLY"
+    },
+    {
+      "word": "OR"
+    },
+    {
+      "word": "ORDER"
+    },
+    {
+      "word": "OUTER"
+    },
+    {
+      "word": "OVERLAPS"
+    },
+    {
+      "word": "PLACING"
+    },
+    {
+      "word": "PRIMARY"
+    },
+    {
+      "word": "REFERENCES"
+    },
+    {
+      "word": "RETURNING"
+    },
+    {
+      "word": "RIGHT"
+    },
+    {
+      "word": "SELECT"
+    },
+    {
+      "word": "SESSION_USER"
+    },
+    {
+      "word": "SIMILAR"
+    },
+    {
+      "word": "SOME"
+    },
+    {
+      "word": "SYMMETRIC"
+    },
+    {
+      "word": "TABLE"
+    },
+    {
+      "word": "THEN"
+    },
+    {
+      "word": "TO"
+    },
+    {
+      "word": "TRAILING"
+    },
+    {
+      "word": "TRUE"
+    },
+    {
+      "word": "UNION"
+    },
+    {
+      "word": "UNIQUE"
+    },
+    {
+      "word": "USER"
+    },
+    {
+      "word": "USING"
+    },
+    {
+      "word": "VARIADIC"
+    },
+    {
+      "word": "VERBOSE"
+    },
+    {
+      "word": "WHEN"
+    },
+    {
+      "word": "WHERE"
+    },
+    {
+      "word": "WITH"
+    }
+  ]
+}

--- a/words/postgresql-9.2.json
+++ b/words/postgresql-9.2.json
@@ -1,6 +1,6 @@
 {
   "platform": "PostgreSQL",
-  "version": "9.1",
+  "version": "9.2",
   "words": [
     {
       "word": "ALL"

--- a/words/postgresql-9.2.json
+++ b/words/postgresql-9.2.json
@@ -1,0 +1,303 @@
+{
+  "platform": "PostgreSQL",
+  "version": "9.1",
+  "words": [
+    {
+      "word": "ALL"
+    },
+    {
+      "word": "ANALYSE"
+    },
+    {
+      "word": "ANALYZE"
+    },
+    {
+      "word": "AND"
+    },
+    {
+      "word": "ANY"
+    },
+    {
+      "word": "ARRAY"
+    },
+    {
+      "word": "AS"
+    },
+    {
+      "word": "ASC"
+    },
+    {
+      "word": "ASYMMETRIC"
+    },
+    {
+      "word": "AUTHORIZATION"
+    },
+    {
+      "word": "BINARY"
+    },
+    {
+      "word": "BOTH"
+    },
+    {
+      "word": "CASE"
+    },
+    {
+      "word": "CAST"
+    },
+    {
+      "word": "CHECK"
+    },
+    {
+      "word": "COLLATE"
+    },
+    {
+      "word": "COLLATION"
+    },
+    {
+      "word": "COLUMN"
+    },
+    {
+      "word": "CONCURRENTLY"
+    },
+    {
+      "word": "CONSTRAINT"
+    },
+    {
+      "word": "CREATE"
+    },
+    {
+      "word": "CROSS"
+    },
+    {
+      "word": "CURRENT_CATALOG"
+    },
+    {
+      "word": "CURRENT_DATE"
+    },
+    {
+      "word": "CURRENT_ROLE"
+    },
+    {
+      "word": "CURRENT_SCHEMA"
+    },
+    {
+      "word": "CURRENT_TIME"
+    },
+    {
+      "word": "CURRENT_TIMESTAMP"
+    },
+    {
+      "word": "CURRENT_USER"
+    },
+    {
+      "word": "DEFAULT"
+    },
+    {
+      "word": "DEFERRABLE"
+    },
+    {
+      "word": "DESC"
+    },
+    {
+      "word": "DISTINCT"
+    },
+    {
+      "word": "DO"
+    },
+    {
+      "word": "ELSE"
+    },
+    {
+      "word": "END"
+    },
+    {
+      "word": "EXCEPT"
+    },
+    {
+      "word": "FALSE"
+    },
+    {
+      "word": "FETCH"
+    },
+    {
+      "word": "FOR"
+    },
+    {
+      "word": "FOREIGN"
+    },
+    {
+      "word": "FREEZE"
+    },
+    {
+      "word": "FROM"
+    },
+    {
+      "word": "FULL"
+    },
+    {
+      "word": "GRANT"
+    },
+    {
+      "word": "GROUP"
+    },
+    {
+      "word": "HAVING"
+    },
+    {
+      "word": "ILIKE"
+    },
+    {
+      "word": "IN"
+    },
+    {
+      "word": "INITIALLY"
+    },
+    {
+      "word": "INNER"
+    },
+    {
+      "word": "INTERSECT"
+    },
+    {
+      "word": "INTO"
+    },
+    {
+      "word": "IS"
+    },
+    {
+      "word": "ISNULL"
+    },
+    {
+      "word": "JOIN"
+    },
+    {
+      "word": "LEADING"
+    },
+    {
+      "word": "LEFT"
+    },
+    {
+      "word": "LIKE"
+    },
+    {
+      "word": "LIMIT"
+    },
+    {
+      "word": "LOCALTIME"
+    },
+    {
+      "word": "LOCALTIMESTAMP"
+    },
+    {
+      "word": "NATURAL"
+    },
+    {
+      "word": "NEW"
+    },
+    {
+      "word": "NOT"
+    },
+    {
+      "word": "NOTNULL"
+    },
+    {
+      "word": "NULL"
+    },
+    {
+      "word": "OFFSET"
+    },
+    {
+      "word": "OLD"
+    },
+    {
+      "word": "ON"
+    },
+    {
+      "word": "ONLY"
+    },
+    {
+      "word": "OR"
+    },
+    {
+      "word": "ORDER"
+    },
+    {
+      "word": "OUTER"
+    },
+    {
+      "word": "OVERLAPS"
+    },
+    {
+      "word": "PLACING"
+    },
+    {
+      "word": "PRIMARY"
+    },
+    {
+      "word": "REFERENCES"
+    },
+    {
+      "word": "RETURNING"
+    },
+    {
+      "word": "RIGHT"
+    },
+    {
+      "word": "SELECT"
+    },
+    {
+      "word": "SESSION_USER"
+    },
+    {
+      "word": "SIMILAR"
+    },
+    {
+      "word": "SOME"
+    },
+    {
+      "word": "SYMMETRIC"
+    },
+    {
+      "word": "TABLE"
+    },
+    {
+      "word": "THEN"
+    },
+    {
+      "word": "TO"
+    },
+    {
+      "word": "TRAILING"
+    },
+    {
+      "word": "TRUE"
+    },
+    {
+      "word": "UNION"
+    },
+    {
+      "word": "UNIQUE"
+    },
+    {
+      "word": "USER"
+    },
+    {
+      "word": "USING"
+    },
+    {
+      "word": "VARIADIC"
+    },
+    {
+      "word": "VERBOSE"
+    },
+    {
+      "word": "WHEN"
+    },
+    {
+      "word": "WHERE"
+    },
+    {
+      "word": "WITH"
+    }
+  ]
+}


### PR DESCRIPTION
postgresql-9.0.json has been created by taking postgresql-8.4.json and applying a diff between Key Words tables of https://www.postgresql.org/docs/8.4/static/sql-keywords-appendix.html and https://www.postgresql.org/docs/9.0/static/sql-keywords-appendix.html

postgresql-9.1.json is equal to postgresql-9.0.json (except the version)

postgresql-9.2.json has been created by taking postgresql-9.1.json and applying a diff between Key Words tables of https://www.postgresql.org/docs/9.1/static/sql-keywords-appendix.html and https://www.postgresql.org/docs/9.2/static/sql-keywords-appendix.html